### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ encoder and decoder for Python.  It is pure Python code with no dependencies.
 
 The encoder can be specialized to provide serialization in any kind of situation,
 without any special support by the objects to be serialized (somewhat like pickle).
-This is best done with the default kwarg to dumps.
+This is best done with the `default` kwarg to the `dson.dumps()` function.
 
 The decoder can handle incoming DSON strings of any specified encoding
 (UTF-8 by default). It can also be specialized to post-process DSON objects with

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is best done with the default kwarg to dumps.
 
 The decoder can handle incoming DSON strings of any specified encoding
 (UTF-8 by default). It can also be specialized to post-process DSON objects with
-the object_hook or object_pairs_hook kwargs.
+the `object_hook` or `object_pairs_hook` kwargs.
 
 `Dogeon` Support:
 
@@ -28,21 +28,21 @@ the object_hook or object_pairs_hook kwargs.
 
 ### How to install `Dogeon`?
 
-    $ pip install dogeon
+    $ pip install Dogeon
 
 ### How to use `Dogeon`?
 
-It has completely the same API with standard `json` library.
+It uses the exact same API as the standard `json` library.
 
+```python
+In [1]: import dson
 
-    In [1]: import dson
+In [2]: dson.loads('such "foo" is "bar". "doge" is "shibe" wow')
+Out[2]: {u'doge': u'shibe', u'foo': u'bar'}
 
-    In [2]: dson.loads('such "foo" is "bar". "doge" is "shibe" wow')
-    Out[2]: {u'doge': u'shibe', u'foo': u'bar'}
-
-    In [3]: dson.dumps({"foo": "bar", "doge": "shibe"})
-    Out[3]: 'such "doge" is "shibe", "foo" is "bar" wow'
-
+In [3]: dson.dumps({"foo": "bar", "doge": "shibe"})
+Out[3]: 'such "doge" is "shibe", "foo" is "bar" wow'
+```
 
 ### How to contribute?
 
@@ -52,7 +52,8 @@ Running tests:
 
 ### Note
 
-Since DSON allow `,.!?` as member separators, `Dogeon` default use `,` as member
-seperator when dumps.
-Since DSON allow `and`, `also` as object element separators, `Dogeon` default use
-`and` as element separators.
+While DSON allows `,.!?` as member separators, `Dogeon` by default uses `,` as
+a member seperator for dumps.
+
+Also, while DSON allows `and`, `also` as object element separators, `Dogeon` by
+default uses `and` as an element separator.


### PR DESCRIPTION
This fixes an inaccuracy (the module name on PyPI is actually "Dogeon"
with a capital "D").

It also makes a few grammar corrections, and adds context highlighting
for the iPython shell examples.
